### PR TITLE
[HOU-175]: Kubernetes Release Automation

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,6 @@ jobs:
           author_name: ${{ secrets.PUBLIC_GHA_ACCESS_USER }}
           author_email: ${{ secrets.PUBLIC_GHA_ACCESS_EMAIL }}
           k8s_config_repo: dmsi-io/gha-go-deploy
-          new_branch: test/${{ github.sha }}
+          new_branch: release/v1.0.0
           skip_tag: true
           GCP_PROJECT_ID: gcp-project-id

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,7 @@ jobs:
           author_name: ${{ secrets.PUBLIC_GHA_ACCESS_USER }}
           author_email: ${{ secrets.PUBLIC_GHA_ACCESS_EMAIL }}
           k8s_config_repo: dmsi-io/gha-go-deploy
-          new_branch: release/v1.0.0
+          branch: release/v1.0.0
+          new_branch: test/${{ github.sha }}
           skip_tag: true
           GCP_PROJECT_ID: gcp-project-id

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
           author_name: ${{ secrets.PUBLIC_GHA_ACCESS_USER }}
           author_email: ${{ secrets.PUBLIC_GHA_ACCESS_EMAIL }}
           k8s_config_repo: dmsi-io/gha-go-deploy
-          branch: release/v1.0.0
+          # branch: release/v1.0.0 # for testing release branch semver tag
           new_branch: test/${{ github.sha }}
           skip_tag: true
           GCP_PROJECT_ID: gcp-project-id

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,23 @@
+name: Test gha-k8s-release
+
+on:
+  push:
+    branches:
+      - feature/*
+
+jobs:
+  test-gha-k8s-release:
+    runs-on: ubuntu-latest
+    name: Test gha-k8s-release
+    steps:
+      - name: Test Run
+        id: release
+        uses: dmsi-io/gha-k8s-release@feature/HOU-166
+        with:
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_GHA_ACCESS_TOKEN }}
+          author_name: ${{ secrets.PUBLIC_GHA_ACCESS_USER }}
+          author_email: ${{ secrets.PUBLIC_GHA_ACCESS_EMAIL }}
+          k8s_config_repo: dmsi-io/gha-go-deploy
+          new_branch: test/${{ github.sha }}
+          skip_tag: true
+          GCP_PROJECT_ID: gcp-project-id

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This GitHub Action is a composite action that handles the pulling and population
 | `force_tag`          | Flag to force tag.                                                                                | `bool`   | `false`   | `false`                     |
 | `skip_tag`           | Flag to skip tagging.                                                                             | `bool`   | `false`   | `false`                     |
 | `new_branch`         | Name of new branch to commit changes to. (used more so to test this repo)                         | `string` | `false`   |                             |
-| `author_name`        | The author name to use for the back merge.                                                        | `string` | `false`   | `github-actions`            |
-| `author_email`       | The email to use for the back merge.                                                              | `string` | `false`   | `github-actions@github.com` |
+| `author_name`        | The author name to use for the commit.                                                            | `string` | `false`   | `github-actions`            |
+| `author_email`       | The email to use for the commit.                                                                  | `string` | `false`   | `github-actions@github.com` |
 | `k8s_directory`      | Location of k8s config files.                                                                     | `string` | `false`   | `k8s`                       |
 | `k8s_config_repo`    | Name of repo that may contain additional default Kubernetes config files.                         | `string` | `false`   |                             |
 | `k8s_repo_directory` | Location of repo k8s config files.                                                                | `string` | `false`   | `k8s`                       |

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# gha-k8s-release
+# GHA Kubernetes Release
+
+[![actions-workflow-main][actions-workflow-main-badge]][actions-workflow-main]
+[![release][release-badge]][release]
+
+This GitHub Action is a composite action that handles the pulling and population of Kubernetes configuration files into a `release/*` branch. This action will also tag the new commit with a provided `semver_tag`.
+
+## Inputs
+
+| NAME                 | DESCRIPTION                                                                                       | TYPE     | REQUIRED  | DEFAULT                     |
+| -------------------- | ------------------------------------------------------------------------------------------------- | -------- | --------- | --------------------------- |
+| `GITHUB_TOKEN`       | GitHub Action Token or PAT.                                                                       | `string` | `true`    | `''`                        |
+| `semver_tag`         | Semver Override Tag. This value will always be used if provided.                                  | `string` | `false`   | `null`                      |
+| `branch`             | Branch override value.                                                                            | `string` | `false`   |                             |
+| `force_tag`          | Flag to force tag.                                                                                | `bool`   | `false`   | `true`                      |
+| `skip_tag`           | Flag to skip tagging.                                                                             | `bool`   | `false`   | `false`                     |
+| `new_branch`         | Name of new branch to commit changes to. (used more so to test this repo)                         | `string` | `false`   |                             |
+| `author_name`        | The author name to use for the back merge.                                                        | `string` | `false`   | `github-actions`            |
+| `author_email`       | The email to use for the back merge.                                                              | `string` | `false`   | `github-actions@github.com` |
+| `k8s_directory`      | Location of k8s config files.                                                                     | `string` | `false`   | `k8s`                       |
+| `k8s_config_repo`    | Name of repo that may contain additional default Kubernetes config files.                         | `string` | `false`   |                             |
+| `k8s_repo_directory` | Location of repo k8s config files.                                                                | `string` | `false`   | `k8s`                       |
+| `GCP_PROJECT_ID`     | ProjectID of the GCP project to deploy to. (only required to populate Docker image tag correctly) | `string` | `false`\* |                             |
+| `REGISTRY_HOSTNAME`  | Hostname of Container Registry.                                                                   | `string` | `false`   | `gcr.io`                    |
+| `SERVICE_NAME`       | Allows to override the desired SERVICE_NAME variable.                                             | `string` | `false`   | `github.repository`         |
+
+## Example
+
+```yaml
+name: Kubernetes Release
+
+on:
+  push:
+    branches:
+      - release/*
+
+jobs:
+  test-gha-k8s-release:
+    runs-on: ubuntu-latest
+    name: Release Kubernetes
+    steps:
+      - name: Release
+        id: release
+        uses: dmsi-io/gha-k8s-release@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_GHA_ACCESS_TOKEN }}
+          author_name: ${{ secrets.PUBLIC_GHA_ACCESS_USER }}
+          author_email: ${{ secrets.PUBLIC_GHA_ACCESS_EMAIL }}
+          k8s_config_repo: dmsi-io/gha-go-deploy
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+```
+
+For a further practical example, see [.github/workflows/release.yml](.github/workflows/main.yml).
+
+<!-- badge links -->
+
+[actions-workflow-main]: https://github.com/dmsi-io/gha-k8s-release/actions/query?workflow%3ATest%20gha-k8s-release
+[actions-workflow-main-badge]: https://img.shields.io/github/workflow/status/dmsi-io/gha-k8s-release/Test%20gha-k8s-release?label=Test%20gha-k8s-release&style=for-the-badge&logo=github
+[release]: https://github.com/dmsi-io/gha-k8s-release/releases
+[release-badge]: https://img.shields.io/github/v/release/dmsi-io/gha-k8s-release?style=for-the-badge&logo=github

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This GitHub Action is a composite action that handles the pulling and population
 | `GITHUB_TOKEN`       | GitHub Action Token or PAT.                                                                       | `string` | `true`    | `''`                        |
 | `semver_tag`         | Semver Override Tag. This value will always be used if provided.                                  | `string` | `false`   | `null`                      |
 | `branch`             | Branch override value.                                                                            | `string` | `false`   |                             |
-| `force_tag`          | Flag to force tag.                                                                                | `bool`   | `false`   | `true`                      |
+| `force_tag`          | Flag to force tag.                                                                                | `bool`   | `false`   | `false`                     |
 | `skip_tag`           | Flag to skip tagging.                                                                             | `bool`   | `false`   | `false`                     |
 | `new_branch`         | Name of new branch to commit changes to. (used more so to test this repo)                         | `string` | `false`   |                             |
 | `author_name`        | The author name to use for the back merge.                                                        | `string` | `false`   | `github-actions`            |

--- a/action.yaml
+++ b/action.yaml
@@ -17,7 +17,7 @@ inputs:
   force_tag:
     description: 'Flag to force tag.'
     required: false
-    default: 'true'
+    default: 'false'
 
   skip_tag:
     description: 'Flag to skip tagging.'

--- a/action.yaml
+++ b/action.yaml
@@ -97,7 +97,7 @@ runs:
       with:
         token: ${{ inputs.GITHUB_TOKEN }}
         repository: ${{ inputs.k8s_config_repo }}
-        path: ${{ github.action_path }}/${{ inputs.k8s_config_repo }}
+        path: ${{ inputs.k8s_config_repo }}
 
     - name: Create k8s directory
       if: inputs.k8s_config_repo != '' && inputs.skip_k8s_release != 'true'
@@ -106,7 +106,7 @@ runs:
 
     - name: Copy missing k8s config files
       if: inputs.k8s_config_repo != '' && inputs.skip_k8s_release != 'true'
-      run: cp -inv ${{ github.action_path }}/${{ inputs.k8s_config_repo }}/${{ inputs.k8s_repo_directory }}/* ${{ inputs.k8s_directory }}
+      run: cp -inv ${{ inputs.k8s_config_repo }}/${{ inputs.k8s_repo_directory }}/* ${{ inputs.k8s_directory }}
       shell: bash
 
     - name: Export Environment Variables
@@ -150,3 +150,4 @@ runs:
         author_email: ${{ inputs.author_email }}
         new_branch: ${{ inputs.new_branch }}
         tag: ${{ steps.tag.outputs.strategy }}
+        add: ${{ inputs.k8s_directory }}

--- a/action.yaml
+++ b/action.yaml
@@ -121,7 +121,7 @@ runs:
     - name: Replace Variables
       run: |
         for filename in *; do
-          envsubst < "$filename" > "$filename"
+          envsubst < "$filename" | sponge "$filename"
         done
       working-directory: ${{ inputs.k8s_directory }}
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -110,7 +110,7 @@ runs:
       shell: bash
 
     - name: Export Environment Variables
-      uses: dmsi-io/gha-env-variables@v1
+      uses: dmsi-io/gha-env-variables@v1.2
       with:
         TLD: ''
         GCP_PROJECT_ID: ${{ inputs.GCP_PROJECT_ID }}

--- a/action.yaml
+++ b/action.yaml
@@ -120,6 +120,8 @@ runs:
 
     - name: Replace Variables
       run: |
+        sudo apt-get install -y moreutils # add sponge CLI tool
+
         for filename in *; do
           envsubst < "$filename" | sponge "$filename"
         done

--- a/action.yaml
+++ b/action.yaml
@@ -11,7 +11,7 @@ inputs:
     required: false
 
   branch:
-    description: 'Branch override flag.'
+    description: 'Branch override value.'
     required: false
 
   force_tag:
@@ -39,7 +39,7 @@ inputs:
     default: 'github-actions@github.com'
 
   k8s_directory:
-    description: 'Location of k8s config files'
+    description: 'Location of k8s config files.'
     required: false
     default: 'k8s'
 
@@ -48,13 +48,13 @@ inputs:
     required: false
 
   k8s_repo_directory:
-    description: 'Location of repo k8s config files'
+    description: 'Location of repo k8s config files.'
     required: false
     default: 'k8s'
 
   GCP_PROJECT_ID:
     description: 'ProjectID of the GCP project to deploy to.'
-    required: true
+    required: false
 
   REGISTRY_HOSTNAME:
     description: 'Hostname of Container Registry.'
@@ -65,14 +65,6 @@ inputs:
     description: 'Allows to override the desired SERVICE_NAME variable.'
     required: false
     default: ${{ github.repository }}
-
-outputs:
-  tag:
-    description: 'The tag value used to create prep release branch.'
-    value: ${{ steps.semver.outputs.tag }}
-  level:
-    description: 'The semver increment level found from commit message.'
-    value: ${{ steps.semver-increment.outputs.level }}
 
 runs:
   using: composite

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,151 @@
+name: 'Prepare Kubernetes Release'
+description: 'Prepares a Kubernetes release by pulling in and populated K8S configs with environment variables and tagging the branch.'
+
+inputs:
+  GITHUB_TOKEN:
+    description: 'GitHub Action Token or PAT'
+    required: true
+
+  semver_tag:
+    description: 'Semver Tag. If not included, will not tag the repo.'
+    required: false
+
+  branch:
+    description: 'Branch override flag.'
+    required: false
+
+  force_tag:
+    description: 'Flag to force tag.'
+    required: false
+    default: 'true'
+
+  skip_tag:
+    description: 'Flag to skip tagging.'
+    required: false
+    default: 'false'
+
+  new_branch:
+    description: 'Name of new branch to commit changes to.'
+    required: false
+
+  author_name:
+    description: 'The author name to use for the merge'
+    required: false
+    default: 'github-actions'
+
+  author_email:
+    description: 'The email to use for the merge'
+    required: false
+    default: 'github-actions@github.com'
+
+  k8s_directory:
+    description: 'Location of k8s config files'
+    required: false
+    default: 'k8s'
+
+  k8s_config_repo:
+    description: 'Name of repo that may contain additional default Kubernetes config files.'
+    required: false
+
+  k8s_repo_directory:
+    description: 'Location of repo k8s config files'
+    required: false
+    default: 'k8s'
+
+  GCP_PROJECT_ID:
+    description: 'ProjectID of the GCP project to deploy to.'
+    required: true
+
+  REGISTRY_HOSTNAME:
+    description: 'Hostname of Container Registry.'
+    default: 'gcr.io'
+    required: false
+
+  SERVICE_NAME:
+    description: 'Allows to override the desired SERVICE_NAME variable.'
+    required: false
+    default: ${{ github.repository }}
+
+outputs:
+  tag:
+    description: 'The tag value used to create prep release branch.'
+    value: ${{ steps.semver.outputs.tag }}
+  level:
+    description: 'The semver increment level found from commit message.'
+    value: ${{ steps.semver-increment.outputs.level }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get Ref
+      id: get_ref
+      uses: dmsi-io/gha-get-ref@v1
+      with:
+        custom_ref: ${{ inputs.branch }}
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        token: ${{ inputs.GITHUB_TOKEN }}
+        ref: ${{ steps.get_ref.outputs.ref_name }}
+
+    ###### Checkout and setup Kubernetes configs
+
+    - name: Checkout K8S Config repo
+      if: inputs.k8s_config_repo != '' && inputs.skip_k8s_release != 'true'
+      uses: actions/checkout@v2
+      with:
+        token: ${{ inputs.GITHUB_TOKEN }}
+        repository: ${{ inputs.k8s_config_repo }}
+        path: ${{ inputs.k8s_config_repo }}
+
+    - name: Create k8s directory
+      if: inputs.k8s_config_repo != '' && inputs.skip_k8s_release != 'true'
+      run: mkdir -p ${{ inputs.k8s_directory }}
+      shell: bash
+
+    - name: Copy missing k8s config files
+      if: inputs.k8s_config_repo != '' && inputs.skip_k8s_release != 'true'
+      run: cp -inv ${{ inputs.k8s_config_repo }}/${{ inputs.k8s_repo_directory }}/* ${{ inputs.k8s_directory }}
+      shell: bash
+
+    - name: Export Environment Variables
+      uses: dmsi-io/gha-env-variables@v1
+      with:
+        TLD: ''
+        GCP_PROJECT_ID: ${{ inputs.GCP_PROJECT_ID }}
+        SERVICE_NAME: ${{ inputs.SERVICE_NAME }}
+        NAMESPACE: ${{ steps.get_ref.outputs.ref_name }}
+        REGISTRY_HOSTNAME: ${{ inputs.REGISTRY_HOSTNAME }}
+
+    - name: Replace Variables
+      run: |
+        for filename in ${{ inputs.k8s_directory }}/*; do
+          cat "$filename" | envsubst > "$filename"
+        done
+      shell: bash
+
+    ###### Commit Change and Tag
+
+    - name: Create Tag Strategy
+      if: inputs.semver_tag != '' && inputs.skip_tag != 'true'
+      id: tag
+      run: |
+        TAG="${{ inputs.semver_tag }}"
+
+        if [[ "${{ inputs.force_tag }}" = "true" ]]; then
+          TAG="$TAG --force"
+        fi
+
+        echo "::set-output name=strategy::$TAG"
+      shell: bash
+
+    - name: Commit Changes and Tag
+      # Commit equivalent to https://github.com/EndBug/add-and-commit/releases/tag/v8.0.2
+      uses: EndBug/add-and-commit@72e246094f1af94def5a07467cd789c503ae8be0
+      with:
+        default_author: user_info
+        author_name: ${{ inputs.author_name }}
+        author_email: ${{ inputs.author_email }}
+        new_branch: ${{ inputs.new_branch }}
+        tag: ${{ steps.tag.outputs.strategy }}

--- a/action.yaml
+++ b/action.yaml
@@ -29,12 +29,12 @@ inputs:
     required: false
 
   author_name:
-    description: 'The author name to use for the merge'
+    description: 'The author name to use for the commit.'
     required: false
     default: 'github-actions'
 
   author_email:
-    description: 'The email to use for the merge'
+    description: 'The email to use for the commit'
     required: false
     default: 'github-actions@github.com'
 

--- a/action.yaml
+++ b/action.yaml
@@ -121,7 +121,7 @@ runs:
     - name: Replace Variables
       run: |
         for filename in ${{ inputs.k8s_directory }}/*; do
-          cat "$filename" | envsubst > "$filename"
+          envsubst < "$filename"
         done
       shell: bash
 

--- a/action.yaml
+++ b/action.yaml
@@ -97,7 +97,7 @@ runs:
       with:
         token: ${{ inputs.GITHUB_TOKEN }}
         repository: ${{ inputs.k8s_config_repo }}
-        path: ${{ inputs.k8s_config_repo }}
+        path: ${{ github.action_path }}/${{ inputs.k8s_config_repo }}
 
     - name: Create k8s directory
       if: inputs.k8s_config_repo != '' && inputs.skip_k8s_release != 'true'
@@ -106,7 +106,7 @@ runs:
 
     - name: Copy missing k8s config files
       if: inputs.k8s_config_repo != '' && inputs.skip_k8s_release != 'true'
-      run: cp -inv ${{ inputs.k8s_config_repo }}/${{ inputs.k8s_repo_directory }}/* ${{ inputs.k8s_directory }}
+      run: cp -inv ${{ github.action_path }}/${{ inputs.k8s_config_repo }}/${{ inputs.k8s_repo_directory }}/* ${{ inputs.k8s_directory }}
       shell: bash
 
     - name: Export Environment Variables
@@ -120,9 +120,10 @@ runs:
 
     - name: Replace Variables
       run: |
-        for filename in ${{ inputs.k8s_directory }}/*; do
-          envsubst < "$filename"
+        for filename in *; do
+          envsubst < "$filename" > "$filename"
         done
+      working-directory: ${{ inputs.k8s_directory }}
       shell: bash
 
     ###### Commit Change and Tag

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $NAMESPACE
+  other: test


### PR DESCRIPTION
## 📑 Description
This GHA is setup to pull in and populate Kubernetes configuration files into a release branch. The intended use case for this action is to utilize `gha-prep-release` to create a `release/<semver>` branch and have this action populate all Kubernetes files and tag the release branch.